### PR TITLE
Update stg_products to have the first value as the supplier id

### DIFF
--- a/dbt_core/models/staging/stg_products.sql
+++ b/dbt_core/models/staging/stg_products.sql
@@ -6,7 +6,7 @@
 
 SELECT
    CAST(id AS INT) AS product_id,
-   CAST(supplier_ids AS STRING) AS supplier_id, --a list od suppliers that sell this product
+   CAST(LEFT(supplier_ids,1) AS INT) AS supplier_id, -- get the first value as the supplier id for some data point
    CAST(product_code AS STRING) AS product_code,
    CAST(product_name AS STRING) AS product_name,
    CAST(description AS STRING) AS description,


### PR DESCRIPTION
in the products table, there are more than one value in attribute: supplier id in a format of #;# (eg: 2;6). Instead of removing the whole rows, it is determined to use the first value as the supplier id for the product because in the order detail table, such products were sold  (ed. product-id 74, 20). In order to save as much as data, the first value from the attribute supplier id will be treated as the supplier id without further information

![Screen Shot 2024-08-19 at 6 07 48 PM](https://github.com/user-attachments/assets/2c3afb35-588a-43d4-8091-2a527eae99ef)
