### PR TITLE
Fetch stage dim and fact tables data modeling

### DIFF
--- a/dbt_core/dbt_project.yml
+++ b/dbt_core/dbt_project.yml
@@ -36,3 +36,8 @@ models:
       +enabled: true
       +materialized: table
       +schema: stg_northwind
+    
+    warehouse:
+      +enabled: true
+      +materialized: table
+      +schema: dwh_northwind

--- a/dbt_core/models/staging/stg_brand_items.sql
+++ b/dbt_core/models/staging/stg_brand_items.sql
@@ -1,0 +1,15 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+-- brand item table with granularity on item level by brand
+-- primary key is rhe brand_item_id
+SELECT
+  SAFE_CAST(_id.oid AS STRING) AS brand_item_id,
+  SAFE_CAST(barcode AS STRING) AS item_barcode, -- CAST barcode to be string as barcode could start with 0
+  SAFE_CAST(brandCode AS STRING) AS brand_code,
+  SAFE_CAST(name AS STRING) AS brand_name,
+  SAFE_CAST(categoryCode AS STRING) category_code,
+  SAFE_CAST(category AS STRING) category
+FROM {{ source ('fetch', 'brands')}}

--- a/dbt_core/models/staging/stg_brand_items.sql
+++ b/dbt_core/models/staging/stg_brand_items.sql
@@ -4,7 +4,7 @@
    )
 }}
 -- brand item table with granularity on item level by brand
--- primary key is rhe brand_item_id
+-- primary key is the brand_item_id
 SELECT
   SAFE_CAST(_id.oid AS STRING) AS brand_item_id,
   SAFE_CAST(barcode AS STRING) AS item_barcode, -- CAST barcode to be string as barcode could start with 0

--- a/dbt_core/models/staging/stg_brands.sql
+++ b/dbt_core/models/staging/stg_brands.sql
@@ -1,0 +1,11 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+-- brand table with granularity on brand
+SELECT DISTINCT
+  brandCode AS brand_code,
+  name AS brand_name,
+  topBrand AS is_top_brand
+FROM {{ source ('fetch', 'brands')}}

--- a/dbt_core/models/staging/stg_products.sql
+++ b/dbt_core/models/staging/stg_products.sql
@@ -6,7 +6,7 @@
 
 SELECT
    CAST(id AS INT) AS product_id,
-   CAST(LEFT(supplier_ids,1) AS INT) AS supplier_id, -- get the first value as the supplier id for some data point
+   CAST(supplier_ids AS STRING) AS supplier_id, --a list od suppliers that sell this product
    CAST(product_code AS STRING) AS product_code,
    CAST(product_name AS STRING) AS product_name,
    CAST(description AS STRING) AS description,

--- a/dbt_core/models/staging/stg_products.sql
+++ b/dbt_core/models/staging/stg_products.sql
@@ -6,7 +6,7 @@
 
 SELECT
    CAST(id AS INT) AS product_id,
-   CAST(supplier_ids AS STRING) AS supplier_id, --a list od suppliers that sell this product
+   CAST(LEFT(supplier_ids,1) AS INT) AS supplier_id, -- get the first value as the supplier id for some data point
    CAST(product_code AS STRING) AS product_code,
    CAST(product_name AS STRING) AS product_name,
    CAST(description AS STRING) AS description,

--- a/dbt_core/models/staging/stg_receipt_items.sql
+++ b/dbt_core/models/staging/stg_receipt_items.sql
@@ -1,0 +1,73 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+-- retrieve the items related info from the receipt
+-- the granularity is on receipt item level
+-- primary key is receipt item id
+WITH update_data_types AS (
+ SELECT
+  SAFE_CAST(_id.oid AS STRING) AS receipt_id,
+  SAFE_CAST(receipt_items.partnerItemId AS INT64) AS item_id,
+  SAFE_CAST(receipt_items.brandCode AS STRING) AS brand_code,
+  COALESCE(
+    SAFE_CAST(receipt_items.barcode AS STRING),
+    SAFE_CAST(receipt_items.userFlaggedBarcode AS STRING)) AS item_barcode,
+  COALESCE(
+    SAFE_CAST(receipt_items.originalReceiptItemText AS STRING), -- retrieve item info from three fields as item name.
+    SAFE_CAST(receipt_items.description AS STRING),  -- ideally, originalReceiptItemText should be the item name.
+    SAFE_CAST(receipt_items.userFlaggedDescription AS STRING)) AS item_name, -- using description as the secondary fields as it also contains valuable item info 
+  COALESCE(
+    SAFE_CAST(receipt_items.description AS STRING),  -- Retrieve item dscription from three fields.
+    SAFE_CAST(receipt_items.userFlaggedDescription AS STRING), -- ideally description and userFlaggedDescription should contain item description
+    SAFE_CAST(receipt_items.originalReceiptItemText AS STRING)) AS item_description, -- using originalReceiptItemText in case the first two fields are null
+  COALESCE(
+    SAFE_CAST(receipt_items.itemPrice AS FLOAT64), -- Use itemPrice and userFlaggedPrice as the item price
+    SAFE_CAST(receipt_items.userFlaggedPrice AS FLOAT64)) AS item_price, -- ideally, itemPrice should be the item price. Use userFlaggedPrice when it is null
+  COALESCE(
+    SAFE_CAST(receipt_items.finalPrice AS FLOAT64), -- Use finalPrice and userFlaggedPrice as final price
+    SAFE_CAST(receipt_items.userFlaggedPrice AS FLOAT64)) AS item_final_price, -- ideally, userFlaggedPrice should be the final item price. Use userFlaggedPrice when it is null
+  COALESCE(
+    SAFE_CAST(receipt_items.quantityPurchased AS INT64), -- Use quantityPurchased and userFlaggedQuantity as the total item quantity purchased for the receipt
+    SAFE_CAST(receipt_items.userFlaggedQuantity AS INT64)) AS quantity, -- Only using userFlaggedQuantity when quantityPurchased is null
+  SAFE_CAST(receipt_items.pointsEarned AS FLOAT64) AS points_earned,
+  SAFE_CAST(receipt_items.deleted AS BOOLEAN) AS is_deleted
+ FROM {{ source ('fetch', 'receipts')}} 
+ CROSS JOIN UNNEST (`rewardsReceiptItemList`) AS receipt_items
+),
+
+-- count the number of line item 
+-- for receipt under 'SUBMITTED' status, it does not contain valid info on receipt level
+-- this is the pre step to assign item id (1) to SUBMITTED receipt
+-- hence, it can be CONCAT with receipt_id and create a receipt item id using TO_HEX in the final SELECT statement
+receipt_item_count AS (
+SELECT
+  receipt_id,
+  COUNT(receipt_id) AS item_count
+FROM update_data_types
+GROUP BY 1
+)
+
+SELECT
+  TO_HEX(SHA256(CONCAT(udt.receipt_id, CASE
+                            WHEN udt.item_id IS NULL AND ric.item_count = 1 THEN 1
+                            ELSE udt.item_id
+                          END))) AS receipt_item_id,
+  udt.receipt_id,
+  CASE
+    WHEN udt.item_id IS NULL AND ric.item_count = 1 THEN 1 -- assign item id (1) to receipt when the number of line item is 1
+    ELSE udt.item_id
+  END AS item_id,
+  udt.brand_code,
+  udt.item_barcode,
+  udt.item_name,
+  udt.item_description,
+  udt.item_price,
+  udt.item_final_price,
+  quantity,
+  points_earned,
+  is_deleted
+FROM update_data_types udt
+JOIN receipt_item_count ric
+  ON udt.receipt_id = ric.receipt_id

--- a/dbt_core/models/staging/stg_receipts.sql
+++ b/dbt_core/models/staging/stg_receipts.sql
@@ -1,0 +1,22 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+--retrieve order level attributes, including id, user_id, total item quantity, spend, purchased date, scanned date
+--event finished date, rewards status, total points earned, bonus points, and points awarded date for the receipt
+--primary key for receipt_id on the receipt/order level
+SELECT
+  SAFE_CAST(_id.oid AS STRING) AS receipt_id,
+  SAFE_CAST(userId AS STRING) AS user_id,
+  SAFE_CAST(purchasedItemCount AS INT64) AS quantity,
+  SAFE_CAST(totalSpent AS FLOAT64) AS total_spent,
+  TIMESTAMP_MILLIS(SAFE_CAST(purchaseDate.date AS INT64)) AS purchase_date,
+  TIMESTAMP_MILLIS(SAFE_CAST(dateScanned.date AS INT64)) AS date_scanned,
+  TIMESTAMP_MILLIS(SAFE_CAST(finishedDate.date AS INT64)) AS finished_date,
+  SAFE_CAST(rewardsReceiptStatus AS STRING) AS rewards_status,
+  SAFE_CAST(pointsEarned AS FLOAT64) AS point_earned,
+  SAFE_CAST(bonusPointsEarned AS FLOAT64) AS bonus_points_earned,
+  SAFE_CAST(bonusPointsEarnedReason AS STRING) AS bonus_point_reason,
+  TIMESTAMP_MILLIS(SAFE_CAST(pointsAwardedDate.date AS INT64)) AS points_awarded_date
+FROM {{ source ('fetch', 'receipts')}} 

--- a/dbt_core/models/staging/stg_users.sql
+++ b/dbt_core/models/staging/stg_users.sql
@@ -1,0 +1,15 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+-- dedup _id.oid: using distinct to remove duplicate _id.oid
+SELECT DISTINCT
+  SAFE_CAST(_id.oid AS STRING) AS user_id,
+  SAFE_CAST(role AS STRING) AS role,
+  SAFE_CAST(state AS STRING) AS state,
+  SAFE_CAST(signUpSource AS STRING) AS signup_source,
+  TIMESTAMP_MILLIS(SAFE_CAST(createdDate.date AS int64)) AS signup_date,
+  TIMESTAMP_MILLIS(SAFE_CAST(lastLogin.date AS int64)) AS last_login_date,
+  SAFE_CAST(active AS BOOLEAN) AS is_active
+FROM {{ source ('fetch', 'users')}}

--- a/dbt_core/models/warehouse/dim tables/dim_brand_items.sql
+++ b/dbt_core/models/warehouse/dim tables/dim_brand_items.sql
@@ -1,0 +1,7 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+SELECT *
+FROM  {{ ref('stg_brand_items')}}

--- a/dbt_core/models/warehouse/dim tables/dim_brands.sql
+++ b/dbt_core/models/warehouse/dim tables/dim_brands.sql
@@ -1,0 +1,7 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+SELECT *
+FROM  {{ ref('stg_brands')}}

--- a/dbt_core/models/warehouse/dim tables/dim_users.sql
+++ b/dbt_core/models/warehouse/dim tables/dim_users.sql
@@ -1,0 +1,7 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+SELECT *
+FROM  {{ ref('stg_users')}}

--- a/dbt_core/models/warehouse/dim_date.sql
+++ b/dbt_core/models/warehouse/dim_date.sql
@@ -1,0 +1,26 @@
+ {{
+   config(
+      materialized = 'table',
+   )
+}}
+
+WITH base AS (
+    SELECT *
+    FROM
+    UNNEST(GENERATE_DATE_ARRAY('2014-01-01', '2050-01-01', INTERVAL 1 DAY)) AS d
+)
+
+SELECT
+  FORMAT_DATE('%F', d) as id,
+  d AS full_date,
+  EXTRACT(YEAR FROM d) AS year,
+  EXTRACT(WEEK FROM d) AS year_week,
+  EXTRACT(DAY FROM d) AS year_day,
+  EXTRACT(YEAR FROM d) AS fiscal_year,
+  FORMAT_DATE('%Q', d) as fiscal_qtr,
+  EXTRACT(MONTH FROM d) AS month,
+  FORMAT_DATE('%B', d) as month_name,
+  FORMAT_DATE('%w', d) AS week_day,
+  FORMAT_DATE('%A', d) AS day_name,
+  (CASE WHEN FORMAT_DATE('%A', d) IN ('Sunday', 'Saturday') THEN 0 ELSE 1 END) AS day_is_weekday,
+FROM base

--- a/dbt_core/models/warehouse/fact tables/fact_receipt_items.sql
+++ b/dbt_core/models/warehouse/fact tables/fact_receipt_items.sql
@@ -1,0 +1,8 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+
+SELECT *
+FROM {{ ref('stg_receipt_items')}}

--- a/dbt_core/models/warehouse/fact tables/fact_receipts.sql
+++ b/dbt_core/models/warehouse/fact tables/fact_receipts.sql
@@ -1,0 +1,8 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+
+SELECT *
+FROM {{ ref('stg_receipts')}}


### PR DESCRIPTION
**Disclaimer:** 
1. BigQuery is used all the time for this project
2. The data models are created using DBT
3. When uploading the datasets (users, brands, and receipts) to BigQuery, I encountered the error : `Invalid field name "$date". Fields must contain the allowed characters, and be at most 300 characters long.` The problem was solved after I **removed the symbol $** from the datasets. example error see below:
![Screen Shot 2025-03-14 at 1 11 59 PM](https://github.com/user-attachments/assets/979467d7-b360-4f61-8110-2970e6c5f883)
4. Bigquery already automatically flattened  the dataset based on the detect schema.  Otherwise, function `JSON_EXTRACT_SCALAR` need to be used to flatten the datasets
5. **Kimball dimensional data modeling** is applied to create the data model. For this project, it contains **stage, fact and dim layers**. In the future, the the business logic get complicated with joins, ti will be handled in **int layer**.
6. the ERD is created on [drawio](the https://drive.google.com/file/d/106JMSDoJ9kh5_kFV4_K-CRPr1msIOfj5/view?usp=sharing)

**Step 1: raw data to stage layer: modify the data type**
These are the stage layers of the data modeling from raw data, users, brands, and receipts. The stage tables include:
- stg_users
- stg_brand_items
- stg_brands,
- stg_receipts
- stg_receipt_items

**Step 2: stage layer tables to dim and fact tables**
The stage tables will be referenced to create dim and fact tables, including:

- dim_users
- dim_brand_items
- dim_brands,
- fact_receipts
- fact_receipt_items