### PR TITLE
Fetch business question - Top 5 brand by scanned month

### DIFF
--- a/dbt_core/dbt_project.yml
+++ b/dbt_core/dbt_project.yml
@@ -36,3 +36,8 @@ models:
       +enabled: true
       +materialized: table
       +schema: stg_northwind
+    
+    warehouse:
+      +enabled: true
+      +materialized: table
+      +schema: dwh_northwind

--- a/dbt_core/models/analytics_obt/monthly_brand_sales_rank.sql
+++ b/dbt_core/models/analytics_obt/monthly_brand_sales_rank.sql
@@ -6,7 +6,7 @@
 -- this table demonstrates the brand rank by sales (items final prices from each receipts) by scanned month
 -- by using brand_sales_rank, it can be filtered to top N brands over time. for example,
 -- as stakeholder is interested in the top 5 brand, use brand_sales_rank <= 5 in the where clause
--- is_current_month and brand_sales_rank <= 5 can be used together to pull the top 5 brand in the moce recent month
+-- is_current_month and brand_sales_rank <= 5 can be used together to pull the top 5 brand in the most recent month
 -- as well as the top 5 brands for the previous month
 
 WITH sales_by_brand AS (

--- a/dbt_core/models/analytics_obt/monthly_brand_sales_rank.sql
+++ b/dbt_core/models/analytics_obt/monthly_brand_sales_rank.sql
@@ -14,7 +14,7 @@ WITH sales_by_brand AS (
     DATE_TRUNC(fr.date_scanned, MONTH) AS scanned_month,
     fri.brand_code AS brand_code,
     db.brand_name,
-    ROUND(SUM(COALESCE(item_final_price,item_price)),2) AS sales,
+    ROUND(SUM(COALESCE(item_final_price,item_price)),2) AS sales, -- in case the final price is null, using the item_price as the secondary value
     SUM(fri.quantity) AS quantity
 
   FROM {{ ref('fact_receipt_items')}} fri

--- a/dbt_core/models/analytics_obt/monthly_brand_sales_rank.sql
+++ b/dbt_core/models/analytics_obt/monthly_brand_sales_rank.sql
@@ -1,0 +1,55 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+-- this table demonstrates the brand rank by sales (items final prices from each receipts) by scanned month
+-- by using brand_sales_rank, it can be filtered to top N brands over time. for example,
+-- as stakeholder is interested in the top 5 brand, use brand_sales_rank <= 5 in the where clause
+-- is_current_month and brand_sales_rank <= 5 can be used together to pull the top 5 brand in the moce recent month
+-- as well as the top 5 brands for the previous month
+
+WITH sales_by_brand AS (
+  SELECT
+    DATE_TRUNC(fr.date_scanned, MONTH) AS scanned_month,
+    fri.brand_code AS brand_code,
+    db.brand_name,
+    ROUND(SUM(COALESCE(item_final_price,item_price)),2) AS sales,
+    SUM(fri.quantity) AS quantity
+
+  FROM {{ ref('fact_receipt_items')}} fri
+  JOIN {{ ref('stg_receipts')}} fr 
+    ON fri.receipt_id = fr.receipt_id
+  LEFT JOIN {{ ref('dim_brands')}} db
+    ON fri.brand_code = db.brand_code
+  GROUP BY 1,2,3
+),
+
+brand_rank AS (
+  SELECT
+    scanned_month,
+    brand_code,
+    brand_name,
+    sales,
+    quantity,
+    DENSE_RANK() OVER (PARTITION BY scanned_month ORDER BY sales DESC) AS brand_sales_rank,
+    ROW_NUMBER() OVER (PARTITION BY scanned_month ORDER BY sales DESC) AS brand_number
+  FROM sales_by_brand
+  WHERE brand_code IS NOT NULL
+)
+
+SELECT
+  scanned_month,
+  brand_code,
+  sales,
+  quantity,
+  brand_sales_rank,
+  LAG(brand_code, 1) OVER (PARTITION BY brand_number ORDER BY scanned_month) AS pre_month_brand,
+  LAG(sales, 1) OVER (PARTITION BY brand_number ORDER BY scanned_month) AS pre_month_brand_sales,
+  CASE
+    WHEN DATE_TRUNC(CURRENT_TIMESTAMP(), MONTH) = scanned_month THEN TRUE
+    ELSE FALSE
+  END AS is_current_month
+FROM brand_rank
+-- WHERE brand_sales_rank <= 5 
+-- ORDER BY scanned_month, brand_sales_rank

--- a/dbt_core/models/staging/stg_brand_items.sql
+++ b/dbt_core/models/staging/stg_brand_items.sql
@@ -1,0 +1,15 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+-- brand item table with granularity on item level by brand
+-- primary key is rhe brand_item_id
+SELECT
+  SAFE_CAST(_id.oid AS STRING) AS brand_item_id,
+  SAFE_CAST(barcode AS STRING) AS item_barcode, -- CAST barcode to be string as barcode could start with 0
+  SAFE_CAST(brandCode AS STRING) AS brand_code,
+  SAFE_CAST(name AS STRING) AS brand_name,
+  SAFE_CAST(categoryCode AS STRING) category_code,
+  SAFE_CAST(category AS STRING) category
+FROM {{ source ('fetch', 'brands')}}

--- a/dbt_core/models/staging/stg_brand_items.sql
+++ b/dbt_core/models/staging/stg_brand_items.sql
@@ -4,7 +4,7 @@
    )
 }}
 -- brand item table with granularity on item level by brand
--- primary key is rhe brand_item_id
+-- primary key is the brand_item_id
 SELECT
   SAFE_CAST(_id.oid AS STRING) AS brand_item_id,
   SAFE_CAST(barcode AS STRING) AS item_barcode, -- CAST barcode to be string as barcode could start with 0

--- a/dbt_core/models/staging/stg_brands.sql
+++ b/dbt_core/models/staging/stg_brands.sql
@@ -1,0 +1,11 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+-- brand table with granularity on brand
+SELECT DISTINCT
+  brandCode AS brand_code,
+  name AS brand_name,
+  topBrand AS is_top_brand
+FROM {{ source ('fetch', 'brands')}}

--- a/dbt_core/models/staging/stg_products.sql
+++ b/dbt_core/models/staging/stg_products.sql
@@ -6,7 +6,7 @@
 
 SELECT
    CAST(id AS INT) AS product_id,
-   CAST(LEFT(supplier_ids,1) AS INT) AS supplier_id, -- get the first value as the supplier id for some data point
+   CAST(supplier_ids AS STRING) AS supplier_id, --a list od suppliers that sell this product
    CAST(product_code AS STRING) AS product_code,
    CAST(product_name AS STRING) AS product_name,
    CAST(description AS STRING) AS description,

--- a/dbt_core/models/staging/stg_products.sql
+++ b/dbt_core/models/staging/stg_products.sql
@@ -6,7 +6,7 @@
 
 SELECT
    CAST(id AS INT) AS product_id,
-   CAST(supplier_ids AS STRING) AS supplier_id, --a list od suppliers that sell this product
+   CAST(LEFT(supplier_ids,1) AS INT) AS supplier_id, -- get the first value as the supplier id for some data point
    CAST(product_code AS STRING) AS product_code,
    CAST(product_name AS STRING) AS product_name,
    CAST(description AS STRING) AS description,

--- a/dbt_core/models/staging/stg_receipt_items.sql
+++ b/dbt_core/models/staging/stg_receipt_items.sql
@@ -1,0 +1,73 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+-- retrieve the items related info from the receipt
+-- the granularity is on receipt item level
+-- primary key is receipt item id
+WITH update_data_types AS (
+ SELECT
+  SAFE_CAST(_id.oid AS STRING) AS receipt_id,
+  SAFE_CAST(receipt_items.partnerItemId AS INT64) AS item_id,
+  SAFE_CAST(receipt_items.brandCode AS STRING) AS brand_code,
+  COALESCE(
+    SAFE_CAST(receipt_items.barcode AS STRING),
+    SAFE_CAST(receipt_items.userFlaggedBarcode AS STRING)) AS item_barcode,
+  COALESCE(
+    SAFE_CAST(receipt_items.originalReceiptItemText AS STRING), -- retrieve item info from three fields as item name.
+    SAFE_CAST(receipt_items.description AS STRING),  -- ideally, originalReceiptItemText should be the item name.
+    SAFE_CAST(receipt_items.userFlaggedDescription AS STRING)) AS item_name, -- using description as the secondary fields as it also contains valuable item info 
+  COALESCE(
+    SAFE_CAST(receipt_items.description AS STRING),  -- Retrieve item dscription from three fields.
+    SAFE_CAST(receipt_items.userFlaggedDescription AS STRING), -- ideally description and userFlaggedDescription should contain item description
+    SAFE_CAST(receipt_items.originalReceiptItemText AS STRING)) AS item_description, -- using originalReceiptItemText in case the first two fields are null
+  COALESCE(
+    SAFE_CAST(receipt_items.itemPrice AS FLOAT64), -- Use itemPrice and userFlaggedPrice as the item price
+    SAFE_CAST(receipt_items.userFlaggedPrice AS FLOAT64)) AS item_price, -- ideally, itemPrice should be the item price. Use userFlaggedPrice when it is null
+  COALESCE(
+    SAFE_CAST(receipt_items.finalPrice AS FLOAT64), -- Use finalPrice and userFlaggedPrice as final price
+    SAFE_CAST(receipt_items.userFlaggedPrice AS FLOAT64)) AS item_final_price, -- ideally, userFlaggedPrice should be the final item price. Use userFlaggedPrice when it is null
+  COALESCE(
+    SAFE_CAST(receipt_items.quantityPurchased AS INT64), -- Use quantityPurchased and userFlaggedQuantity as the total item quantity purchased for the receipt
+    SAFE_CAST(receipt_items.userFlaggedQuantity AS INT64)) AS quantity, -- Only using userFlaggedQuantity when quantityPurchased is null
+  SAFE_CAST(receipt_items.pointsEarned AS FLOAT64) AS points_earned,
+  SAFE_CAST(receipt_items.deleted AS BOOLEAN) AS is_deleted
+ FROM {{ source ('fetch', 'receipts')}} 
+ CROSS JOIN UNNEST (`rewardsReceiptItemList`) AS receipt_items
+),
+
+-- count the number of line item 
+-- for receipt under 'SUBMITTED' status, it does not contain valid info on receipt level
+-- this is the pre step to assign item id (1) to SUBMITTED receipt
+-- hence, it can be CONCAT with receipt_id and create a receipt item id using TO_HEX in the final SELECT statement
+receipt_item_count AS (
+SELECT
+  receipt_id,
+  COUNT(receipt_id) AS item_count
+FROM update_data_types
+GROUP BY 1
+)
+
+SELECT
+  TO_HEX(SHA256(CONCAT(udt.receipt_id, CASE
+                            WHEN udt.item_id IS NULL AND ric.item_count = 1 THEN 1
+                            ELSE udt.item_id
+                          END))) AS receipt_item_id,
+  udt.receipt_id,
+  CASE
+    WHEN udt.item_id IS NULL AND ric.item_count = 1 THEN 1 -- assign item id (1) to receipt when the number of line item is 1
+    ELSE udt.item_id
+  END AS item_id,
+  udt.brand_code,
+  udt.item_barcode,
+  udt.item_name,
+  udt.item_description,
+  udt.item_price,
+  udt.item_final_price,
+  quantity,
+  points_earned,
+  is_deleted
+FROM update_data_types udt
+JOIN receipt_item_count ric
+  ON udt.receipt_id = ric.receipt_id

--- a/dbt_core/models/staging/stg_receipts.sql
+++ b/dbt_core/models/staging/stg_receipts.sql
@@ -1,0 +1,22 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+--retrieve order level attributes, including id, user_id, total item quantity, spend, purchased date, scanned date
+--event finished date, rewards status, total points earned, bonus points, and points awarded date for the receipt
+--primary key for receipt_id on the receipt/order level
+SELECT
+  SAFE_CAST(_id.oid AS STRING) AS receipt_id,
+  SAFE_CAST(userId AS STRING) AS user_id,
+  SAFE_CAST(purchasedItemCount AS INT64) AS quantity,
+  SAFE_CAST(totalSpent AS FLOAT64) AS total_spent,
+  TIMESTAMP_MILLIS(SAFE_CAST(purchaseDate.date AS INT64)) AS purchase_date,
+  TIMESTAMP_MILLIS(SAFE_CAST(dateScanned.date AS INT64)) AS date_scanned,
+  TIMESTAMP_MILLIS(SAFE_CAST(finishedDate.date AS INT64)) AS finished_date,
+  SAFE_CAST(rewardsReceiptStatus AS STRING) AS rewards_status,
+  SAFE_CAST(pointsEarned AS FLOAT64) AS point_earned,
+  SAFE_CAST(bonusPointsEarned AS FLOAT64) AS bonus_points_earned,
+  SAFE_CAST(bonusPointsEarnedReason AS STRING) AS bonus_point_reason,
+  TIMESTAMP_MILLIS(SAFE_CAST(pointsAwardedDate.date AS INT64)) AS points_awarded_date
+FROM {{ source ('fetch', 'receipts')}} 

--- a/dbt_core/models/staging/stg_users.sql
+++ b/dbt_core/models/staging/stg_users.sql
@@ -1,0 +1,15 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+-- dedup _id.oid: using distinct to remove duplicate _id.oid
+SELECT DISTINCT
+  SAFE_CAST(_id.oid AS STRING) AS user_id,
+  SAFE_CAST(role AS STRING) AS role,
+  SAFE_CAST(state AS STRING) AS state,
+  SAFE_CAST(signUpSource AS STRING) AS signup_source,
+  TIMESTAMP_MILLIS(SAFE_CAST(createdDate.date AS int64)) AS signup_date,
+  TIMESTAMP_MILLIS(SAFE_CAST(lastLogin.date AS int64)) AS last_login_date,
+  SAFE_CAST(active AS BOOLEAN) AS is_active
+FROM {{ source ('fetch', 'users')}}

--- a/dbt_core/models/warehouse/dim tables/dim_brand_items.sql
+++ b/dbt_core/models/warehouse/dim tables/dim_brand_items.sql
@@ -1,0 +1,7 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+SELECT *
+FROM  {{ ref('stg_brand_items')}}

--- a/dbt_core/models/warehouse/dim tables/dim_brands.sql
+++ b/dbt_core/models/warehouse/dim tables/dim_brands.sql
@@ -1,0 +1,7 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+SELECT *
+FROM  {{ ref('stg_brands')}}

--- a/dbt_core/models/warehouse/dim tables/dim_users.sql
+++ b/dbt_core/models/warehouse/dim tables/dim_users.sql
@@ -1,0 +1,7 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+SELECT *
+FROM  {{ ref('stg_users')}}

--- a/dbt_core/models/warehouse/dim_date.sql
+++ b/dbt_core/models/warehouse/dim_date.sql
@@ -1,0 +1,26 @@
+ {{
+   config(
+      materialized = 'table',
+   )
+}}
+
+WITH base AS (
+    SELECT *
+    FROM
+    UNNEST(GENERATE_DATE_ARRAY('2014-01-01', '2050-01-01', INTERVAL 1 DAY)) AS d
+)
+
+SELECT
+  FORMAT_DATE('%F', d) as id,
+  d AS full_date,
+  EXTRACT(YEAR FROM d) AS year,
+  EXTRACT(WEEK FROM d) AS year_week,
+  EXTRACT(DAY FROM d) AS year_day,
+  EXTRACT(YEAR FROM d) AS fiscal_year,
+  FORMAT_DATE('%Q', d) as fiscal_qtr,
+  EXTRACT(MONTH FROM d) AS month,
+  FORMAT_DATE('%B', d) as month_name,
+  FORMAT_DATE('%w', d) AS week_day,
+  FORMAT_DATE('%A', d) AS day_name,
+  (CASE WHEN FORMAT_DATE('%A', d) IN ('Sunday', 'Saturday') THEN 0 ELSE 1 END) AS day_is_weekday,
+FROM base

--- a/dbt_core/models/warehouse/fact tables/fact_receipt_items.sql
+++ b/dbt_core/models/warehouse/fact tables/fact_receipt_items.sql
@@ -1,0 +1,8 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+
+SELECT *
+FROM {{ ref('stg_receipt_items')}}

--- a/dbt_core/models/warehouse/fact tables/fact_receipts.sql
+++ b/dbt_core/models/warehouse/fact tables/fact_receipts.sql
@@ -1,0 +1,8 @@
+ {{
+   config(
+      materialized = 'table'
+   )
+}}
+
+SELECT *
+FROM {{ ref('stg_receipts')}}


### PR DESCRIPTION
This table is created to answer questions:

- What are the top 5 brands by receipts scanned for most recent month?
- How does the ranking of the top 5 brands by receipts scanned for the recent month compare to the ranking for the previous month?

The table contains: receipt scanned month, brand code, sales based on item final price, quantity (item quantity from receipts), and brand_sales_rank (rank base on sales), pre_month_brand (the brand that rank the same top N for the previous month), pre_month_brand_sales, is_current_month.

![Screen Shot 2025-03-14 at 12 53 56 PM](https://github.com/user-attachments/assets/77993714-bf4e-40b1-9117-0bd7f568286b)

To answer the specific questions above, it can bed filter to brand_sales_rank <= 5 and is_current_month. Besides, the table can also be used to understand how brands sales change over time

DBT run:

![Screen Shot 2025-03-14 at 12 45 52 PM](https://github.com/user-attachments/assets/d5d0d28c-31ed-47fa-bc59-83dce25d2567)
